### PR TITLE
hidden-desktop and visible desktop are deprecated in bootstrap 3

### DIFF
--- a/lib/bootstrap_calendar_rails/view_helper.rb
+++ b/lib/bootstrap_calendar_rails/view_helper.rb
@@ -74,8 +74,8 @@ module BootstrapCalendarRails
         # return header, which contains both desktop and mobile day names
         def header
           content_tag 'div', class: "cal-row-fluid cal-row-head" do
-            build_header(day_names, "cal-span1 visible-desktop") +
-            build_header(mobile_day_names, "cal-span1 hidden-desktop")
+            build_header(day_names, "cal-span1 hidden-xs") +
+            build_header(mobile_day_names, "cal-span1 visible-xs")
           end
         end
 


### PR DESCRIPTION
We should use visible-xs and hidden-xs.
